### PR TITLE
fix: external link 404 problem

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,27 @@
+import Url from 'url-parse';
+import closest from 'dom-closest';
+
+// 解决 Gatsby 单页架构下，首页的子站点链接会跳转到 404 的问题
+// 详见：https://github.com/antvis/antvis.github.io/pull/39
+window.addEventListener('click', e => {
+  let node;
+  if (e.target.tagName === 'A') {
+    node = e.target;
+  } else {
+    node = closest(e.target, 'a');
+  }
+  const href = node.getAttribute('href');
+  if (!node || !href) {
+    return;
+  }
+  const { pathname } = new Url(href);
+  // 这是 AntV 子站点的外链
+  if (/g2|g2plot|L7|l7|g|graphin|g6|f2|x6/.test(pathname.split('/')[1])) {
+    e.preventDefault();
+    if (process.env.NODE_ENV === 'production') {
+      window.location = href;
+    } else if (!href.startsWith('http')) {
+      window.location = `https://antvis.github.io${href}`;
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/react-dom": "^16.9.1",
     "antd": "^3.23.6",
     "classnames": "^2.2.6",
+    "dom-closest": "^0.2.0",
     "gatsby": "^2.15.36",
     "gh-pages": "^2.1.1",
     "husky": "^3.0.8",
@@ -35,7 +36,8 @@
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
     "react-i18next": "^11.0.1",
-    "typescript": "^3.6.4"
+    "typescript": "^3.6.4",
+    "url-parse": "^1.4.7"
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
修复点击子产品链接都是 404 的问题，这个问题只发生在首页。

原因是 gatsby 都是 reach-router 的前端路由，子站点由于有 pathPrefix 隔离，路由信息互不包含，而首页里是 `/` 开头，子站点路径都会进入首页的 404。

现在在这里加一段比较恶心的全局链接点击拦截来解决，对于手动 navigate 的跳转方式无效。希望后面能找到更优雅的方案。