### PR TITLE
fix: body background color

### DIFF
--- a/site/pages/d2.en.tsx
+++ b/site/pages/d2.en.tsx
@@ -1,3 +1,3 @@
-import AboutUsIndex from './about.zh';
+import D2 from './d2.zh';
 
-export default AboutUsIndex;
+export default D2;

--- a/site/pages/index.less
+++ b/site/pages/index.less
@@ -1,5 +1,6 @@
 body {
   -webkit-overflow-scrolling: touch;
+  background-color: #fff;
 }
 .subpage-container {
   display: flex;


### PR DESCRIPTION
D2 页面引入 ant-mobile.css 导致 body 背景色样式出问题
https://antv.vision/en/docs/specification/principles
![image](https://user-images.githubusercontent.com/35586469/101434711-0cca2380-3946-11eb-896a-83378b45472c.png)

测试 D2 页面没有影响，同时将 /en/d2 同样引用 /zh/d2
![image](https://user-images.githubusercontent.com/35586469/101434797-308d6980-3946-11eb-8683-a679342d1402.png)
