### PR TITLE
fix: correct the urls of g6 demos for the banner

### DIFF
--- a/site/data/banner-info.json
+++ b/site/data/banner-info.json
@@ -181,7 +181,7 @@
           "title_zh": "决策树",
           "title_en": "Decision Tree",
           "host": "https://g6.antv.vision/",
-          "path": "/examples/case/customTree#decisionTree",
+          "path": "/examples/case/treeDemos#decisionTree",
           "ratio": 1.46
         },
         {
@@ -205,7 +205,7 @@
           "title_zh": "圣诞推文可视化",
           "title_en": "Christmas Bubbles",
           "host": "https://g6.antv.vision/",
-          "path": "/examples/case/newsDemo#christmasBubbles",
+          "path": "/examples/case/graphDemos/#christmasBubbles",
           "ratio": 1.46
         },
         {


### PR DESCRIPTION
fix: correct the urls of g6 demos for the banner