### PR TITLE
docs(typo): Change target attribute from _black to _blank

### DIFF
--- a/site/components/ComplexCharts/index.tsx
+++ b/site/components/ComplexCharts/index.tsx
@@ -44,7 +44,7 @@ export function ComplexCharts() {
       <a
         className={styles.content}
         href={transformUrl({ url: select.link, language, isChinaMirrorHost })}
-        target='_black'
+        target='_blank'
       >
         <video
           muted={true}

--- a/site/components/LinkCharts/index.tsx
+++ b/site/components/LinkCharts/index.tsx
@@ -57,7 +57,7 @@ export function LinkCharts() {
         >
           {
             data.map((data) => {
-              return <a className={styles.chart} href={transformUrl({ url: data.link, language, isChinaMirrorHost })} target='_black' >
+              return <a className={styles.chart} href={transformUrl({ url: data.link, language, isChinaMirrorHost })} target='_blank' >
                 <div className={styles.title}>{useT(data.title)}</div>
                 <div className={styles.subTitle}>
                   <OverflowedText text={useT(data.subTitle)} maxWidth={341} />

--- a/site/components/ProjectCard/index.tsx
+++ b/site/components/ProjectCard/index.tsx
@@ -241,7 +241,7 @@ export function ProjectCard() {
                     className={classNames(col.classNames, styles.card)}
                     href={url && transformUrl({ url, language, isChinaMirrorHost })}
                     style={{ cursor: url ? 'pointer' : 'default' }}
-                    target='_black'
+                    target='_blank'
                   >
                     {icon && <img src={icon} alt={newTitle} />}
                     {isSort ?


### PR DESCRIPTION
This commit addresses the issue where page navigation incorrectly overwrote the content of previously opened tabs. By changing the target attribute of the a-tag from _black to _blank, new pages will now open in a new tab, preventing the overwriting of existing tabs.